### PR TITLE
Serialization Fix & na_trade tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Neo alias is dapp built on NEO blockchain. The purpose of NA is to make the bloc
 0. code cleanup
     -   setup naming convetion
     -   change boolean return values to integer exit codes (+documentation)
-    -   add units test where possible
+    -   improve tests and divide them per gateway
     -   after improvement of compiler --> fix classes 
     -   document Dynamic SC calls
     -   create ABI documentation

--- a/nas/wrappers/storage.py
+++ b/nas/wrappers/storage.py
@@ -103,8 +103,11 @@ class Storage:
         # now we need to know how many bytes the length of the array
         # will take to store
 
+        # for storing empty items in array we have to use zero byte
+        if stuff_len == 0:
+            byte_len = b'\x00'
         # this is one byte
-        if stuff_len <= 255:
+        elif stuff_len <= 255:
             byte_len = b'\x01'
         # two byte
         elif stuff_len <= 65535:

--- a/tests/tests_to_run.py
+++ b/tests/tests_to_run.py
@@ -111,7 +111,7 @@ def get_tests() -> []:
 
 #region NA - alias data
     
-    [  [[bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'\x00m|M'), bytearray(b'e\xfc\x88W'), bytearray(b'\x01'), bytearray(b'\x01'), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b'')]], #expected result
+    [  [[bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'\x00m|M'), bytearray(b'e\xfc\x88W'), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b'')]], #expected result
     #arguments
     [ path_to_avm, 'test', '0710', '10', 'True', 'False', 'na_alias_data', '["'+test_neo_acc+'",4]']],
 
@@ -159,7 +159,7 @@ def get_tests() -> []:
     #arguments
     [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'na_renew', '["'+test_neo_acc+'",1469200101,0]']],
 
-    [  [[bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'\xe56\x92W'), bytearray(b'e\xfc\x88W'), bytearray(b'\x01'), bytearray(b'\x01'), bytearray(b'\x01'), bytearray(b''), bytearray(b''), bytearray(b'')]], #expected result
+    [  [[bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'\xe56\x92W'), bytearray(b'e\xfc\x88W'), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b'')]], #expected result
     #arguments
     [ path_to_avm, 'test', '0710', '10', 'True', 'False', 'na_alias_data', '["'+test_neo_acc+'",0]']],
 
@@ -175,5 +175,41 @@ def get_tests() -> []:
     [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'na_query', '["'+test_neo_acc+'",4]']],
 #endregion NA - delete
 
+#region NA - trading
+
+    [  [b'Alias registred: custom_alias'+str.encode(test_neo_acc)], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'na_register', '["custom_alias'+test_neo_acc+'","AZRtyq1woyVP8va9uReGM3tsp7YtX33Nrw",0,"random_target",1519912704]'],
+    1 ],
+
+    [  [b'Put on sale.'], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'na_offer_sell', '["custom_alias'+test_neo_acc+'", 1000]'], 
+    1 ],
+
+    [  [[bytearray(b'random_target'), bytearray(b'\xc1\xab\x0e\xce\x99\xdbA\xfcCM\xbb\x18\x13\xf2\x04\xea{\xf5z`'), bytearray(b'\xe56\x92W'), bytearray(b'e\xfc\x88W'), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b'\x01'), bytearray(b'\xe8\x03')]], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '10', 'True', 'False', 'na_alias_data', '["custom_alias'+test_neo_acc+'"]']],
+
+    [  [b'Sold.'], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'na_offer_buy', '["custom_alias'+test_neo_acc+'", "ASnSxavKzDvwXh3ZLxBWhqMbbntwn2TJBM", "new_target", 1500, 1519912704 ]']],
+
+    [  [[bytearray(b'new_target'), bytearray(b'x\xc50\xe2V\xef\x8c\xd6\x0b\xf4+\x0f\xb9\x02\xe8\x9eFQ\xc7\xb7'), bytearray(b'\xe56\x92W'), bytearray(b'e\xfc\x88W'), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b''), bytearray(b'')]], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '10', 'True', 'False', 'na_alias_data', '["custom_alias'+test_neo_acc+'"]']],
+
+    [  [b'Alias custom_alias'+str.encode(test_neo_acc)+b' type  deleted.'], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'na_delete', '["custom_alias'+test_neo_acc+'"]'], 
+    ],
+
+    [ [b'Transfer completed.'], #expected result
+    #arguments
+    [ path_to_avm, 'test', '0710', '05', 'True', 'False', 'transfer','[ "AZRtyq1woyVP8va9uReGM3tsp7YtX33Nrw", "ASnSxavKzDvwXh3ZLxBWhqMbbntwn2TJBM", 1000]'],
+    1 ],
+
+
+#endregion NA - trading
     ]
 


### PR DESCRIPTION
Fixed:
- False, 0 values have zero length and therefor its length is represented by b'', what in serialization caused to seialize array [ 0, 0, 0 ] as b'\x01\x01\x01', what wouldn't be properly deserialized. Instead the b'' length has to be represented with b'\x00', which results in serialization of given array to b'\x00\x00\x00' and proper desrialization back to [ 0, 0, 0 ]

Tests:
- added automated tests for alias trading